### PR TITLE
Changes to settle down jumpy beacons and more!

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ confusion with distance calculation.
 # How is Distance Calculated?
 
 Distance is calculated (in feet) using the following formula: 10 ^ ((Measured Power - RSSI)/(10 * N)) * 3.28084
-- N is set to a value of "2" for low-strength beacons
+- N is now adjustable. Default is set to "2" for low-strength beacons but can be adjusted to match your beacons
 - If the beacon is not present (or the distance cannot be calculated), the distance value is set to 999999999 (this is also true for the rssi and power values).  The reason for this
 is to make home automation rules easier to create (i.e., "if my beacon present and less than 100 feet away" will still work as expected if distance cannot be calculated).  This is by design.
+- You can decide the number of retries before marking as Departed. Great for jumpy beacons!
 - **NOTE: While distance is calculated, please note it is an estimate.  The detection of presence of a beacon will be much more reliable than the distance calculation.
 If you decide to use distance in your home automations, it is recommended you use a range (e.g. <= 35 feet away).  You will need to test with your beacon in your environment
 and see what distance values are calculated before creating home automations using the distance (custom) attribute.**

--- a/ble-beacon.groovy
+++ b/ble-beacon.groovy
@@ -4,7 +4,7 @@ def deviceVersion() { return "1.3.1" }
 
 metadata {
 	definition (
-        name: "BLE Beacon", 
+        name: "BLE Beacon Modified", 
         namespace: "ajardolino3", 
         author: "Art Ardolino")
     {
@@ -18,6 +18,7 @@ metadata {
         attribute "distance", "number"
         attribute "type", "string"
         attribute "since", "string"
+        attribute "depCheck", "number"
 	}
     preferences() {    	
         section(""){
@@ -33,6 +34,7 @@ def installed() {
     sendEvent(name: "distance", value: 999999999)
     sendEvent(name: "type", value: "unknown")
     sendEvent(name: "since", value: "unknown")
+    sendEvent(name: "depCheck", value: 0)
 }
 
 def arrived() {
@@ -49,5 +51,6 @@ def departed() {
     sendEvent(name: "distance", value: 999999999)
     def theWhen = new Date()
     sendEvent(name: "since", value: theWhen)
+    sendEvent(name: "depCheck", value: 0)
     if(logEnable) log.info "Beacon has Departed"
 }

--- a/ble-beacon.groovy
+++ b/ble-beacon.groovy
@@ -1,6 +1,6 @@
 import groovy.json.*
 
-def deviceVersion() { return "1.3.0" }
+def deviceVersion() { return "1.3.1" }
 
 metadata {
 	definition (
@@ -17,7 +17,13 @@ metadata {
         attribute "power", "number"
         attribute "distance", "number"
         attribute "type", "string"
-	}   
+        attribute "since", "string"
+	}
+    preferences() {    	
+        section(""){
+            input "logEnable", "bool", title: "Enable logging", required: true, defaultValue: true
+        }
+    }
 }
 
 def installed() {
@@ -26,10 +32,14 @@ def installed() {
     sendEvent(name: "power", value: 999999999)
     sendEvent(name: "distance", value: 999999999)
     sendEvent(name: "type", value: "unknown")
+    sendEvent(name: "since", value: "unknown")
 }
 
 def arrived() {
     sendEvent(name: "presence", value: "present", descriptionText: "BLE beacon has arrived.")
+    def theWhen = new Date()
+    sendEvent(name: "since", value: theWhen)
+    if(logEnable) log.info "Beacon has Arrived"
 }
 
 def departed() {
@@ -37,4 +47,7 @@ def departed() {
     sendEvent(name: "rssi", value: 999999999)
     sendEvent(name: "power", value: 999999999)
     sendEvent(name: "distance", value: 999999999)
+    def theWhen = new Date()
+    sendEvent(name: "since", value: theWhen)
+    if(logEnable) log.info "Beacon has Departed"
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "BLE Gateway Manager",
   "author": "Art Ardolino",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2023-02-02",
   "apps": [


### PR DESCRIPTION
app:
Added code to settle down jumpy (arrived/departed/arrived/departed) beacons
Added 'Number of retries before marking as Departed' input option
Added 'Environment Value (2..4)' input option
Added 'Enable description logging' input option - when off, there is no logging of the info stuff

driver:
Added 'Since' attribute
Added 'Enable debug logging' input option

Thanks for your consideration (and great app/driver!)